### PR TITLE
Prevent adding `Remove-Alias` on PowerShell >= 6

### DIFF
--- a/src/aliases.ps1
+++ b/src/aliases.ps1
@@ -1,14 +1,14 @@
 . $PSScriptRoot\utils.ps1
 
 # Prevent conflict with built-in aliases
-Remove-Alias gc
-Remove-Alias gcb
-Remove-Alias gcm
-Remove-Alias gcs
-Remove-Alias gl
-Remove-Alias gm
-Remove-Alias gp
-Remove-Alias gpv
+Remove-Alias gc -Force
+Remove-Alias gcb -Force
+Remove-Alias gcm -Force
+Remove-Alias gcs -Force
+Remove-Alias gl -Force
+Remove-Alias gm -Force
+Remove-Alias gp -Force
+Remove-Alias gpv -Force
 
 function g {
 	git $args

--- a/src/utils.ps1
+++ b/src/utils.ps1
@@ -12,9 +12,14 @@ function Get-Git-CurrentBranch {
 	}
 }
 
-function Remove-Alias ([string] $AliasName) {
-	while (Test-Path Alias:$AliasName) {
-		Remove-Item Alias:$AliasName -Force 2> $null
+# Don't add `Remove-Alias` on PowerShell >= 6.
+# PowerShell >= 6 already has built-in `Remove-Alias`.
+# Let use built-in `Remove-Alias` on PowerShell >= 6.
+if ($PSVersionTable.PSVersion.Major -le 5) {
+	function Remove-Alias ([string] $AliasName) {
+		while (Test-Path Alias:$AliasName) {
+			Remove-Item Alias:$AliasName -Force 2> $null
+		}
 	}
 }
 


### PR DESCRIPTION
Fix #18.