### PR TITLE
Narrow down PowerShell Gallery link to point to a package

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A [PowerShell](https://microsoft.com/powershell) module that provide partial **[
 
 ## ⚙️ Installation
 
-Install from [PowerShell Gallery](https://www.powershellgallery.com/)
+Install from [PowerShell Gallery](https://www.powershellgallery.com/packages/git-aliases)
 
 ```powershell
 Install-Module git-aliases -Scope CurrentUser -AllowClobber


### PR DESCRIPTION
PowerShell Gallery is a great website, but we probably want to show users our particular package instead.