### PR TITLE
Add `grst` alias for `git restore --staged`

### DIFF
--- a/src/aliases.ps1
+++ b/src/aliases.ps1
@@ -305,6 +305,9 @@ function grrm {
 function grs {
 	git restore $args
 }
+function grst {
+	git restore --staged $args
+}
 function grset {
 	git remote set-url $args
 }

--- a/src/git-aliases.psm1
+++ b/src/git-aliases.psm1
@@ -95,6 +95,7 @@ $FunctionsToExport = @(
 	'grrm',
 	'grset',
 	'grs',
+	'grst',
 	'grt',
 	'gru',
 	'grup',


### PR DESCRIPTION
Closes #38

- Add `grst` alias for `git restore --staged`
- Update `git-aliases.psm1` with `grst` alias

[src/git-aliases.psm1]
- Add `grst` alias to `git-aliases.psm1` [src/aliases.ps1]
- Add `grst` alias for `git restore --staged`